### PR TITLE
Fix typo in performance single stat

### DIFF
--- a/config/grafana/provisioning/dashboards/lighthouse-dashboard.json
+++ b/config/grafana/provisioning/dashboards/lighthouse-dashboard.json
@@ -190,7 +190,7 @@
 					]
 				},
 				{
-					"alias": "Perfromance",
+					"alias": "Performance",
 					"groupBy": [],
 					"limit": "1",
 					"measurement": "performance-score",


### PR DESCRIPTION
Small typo in perf dashboard

- [N/A] Documentation
- [N/A] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

